### PR TITLE
Added spawning multiple peds in distance

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -9,7 +9,7 @@ Citizen.CreateThread(function()
 			local dist = #(playerCoords - v.coords)
 
 			if dist < Config.Distance and not peds[k] then
-				local ped = nearPed(v.model, v.coords, v.heading, v.gender, v.animDict, v.animName)
+				local ped = nearPed(v.model, v.coords, v.heading, v.gender, v.animDict, v.animName, v.scenario)
 				peds[k] = {ped = ped}
 			end
 			
@@ -27,7 +27,7 @@ Citizen.CreateThread(function()
 	end
 end)
 
-function nearPed(model, coords, heading, gender, animDict, animName)
+function nearPed(model, coords, heading, gender, animDict, animName, scenario)
 --AddEventHandler('nearPed', function(model, coords, heading, gender, animDict, animName)
 	-- Request the models of the peds from the server, so they can be ready to spawn.
 	RequestModel(GetHashKey(model))
@@ -74,6 +74,10 @@ function nearPed(model, coords, heading, gender, animDict, animName)
 			Citizen.Wait(1)
 		end
 		TaskPlayAnim(ped, animDict, animName, 8.0, 0, -1, 1, 0, 0, 0)
+	end
+
+	if scenario then
+		TaskStartScenarioInPlace(ped, scenario, 0, true) -- begins peds animation
 	end
 	
 	if Config.Fade then

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,37 +1,34 @@
 local genderNum = 0
-local isNearPed = false
-local ped
-local hasAlreadyEntered = false
+local peds = {}
 
 Citizen.CreateThread(function()
-
 	while true do
-		Citizen.Wait(1)
+		Citizen.Wait(500)
 		for k,v in pairs (Config.PedList) do
 			local playerCoords = GetEntityCoords(PlayerPedId())
 			local dist = #(playerCoords - v.coords)
-			
-			if dist < Config.Distance and hasAlreadyEntered == false then
-				TriggerEvent('nearPed', v.model, v.coords, v.heading, v.gender, v.animDict, v.animName)
-				hasAlreadyEntered = true
+
+			if dist < Config.Distance and not peds[k] then
+				local ped = nearPed(v.model, v.coords, v.heading, v.gender, v.animDict, v.animName)
+				peds[k] = {ped = ped}
 			end
-			if dist >= Config.Distance and dist <= Config.Distance + 1 then
+			
+			if dist >= Config.Distance and peds[k] then
 				if Config.Fade then
 					for i = 255, 0, -51 do
 						Citizen.Wait(50)
-						SetEntityAlpha(ped, i, false)
+						SetEntityAlpha(peds[k].ped, i, false)
 					end
 				end
-				hasAlreadyEntered = false
-				DeletePed(ped)
+				DeletePed(peds[k].ped)
+				peds[k] = nil
 			end
 		end
 	end
-	
-	
 end)
 
-AddEventHandler('nearPed', function(model, coords, heading, gender, animDict, animName)
+function nearPed(model, coords, heading, gender, animDict, animName)
+--AddEventHandler('nearPed', function(model, coords, heading, gender, animDict, animName)
 	-- Request the models of the peds from the server, so they can be ready to spawn.
 	RequestModel(GetHashKey(model))
 	while not HasModelLoaded(GetHashKey(model)) do
@@ -85,4 +82,6 @@ AddEventHandler('nearPed', function(model, coords, heading, gender, animDict, an
 			SetEntityAlpha(ped, i, false)
 		end
 	end
-end)
+
+	return ped
+end

--- a/client/main.lua
+++ b/client/main.lua
@@ -4,7 +4,8 @@ local peds = {}
 Citizen.CreateThread(function()
 	while true do
 		Citizen.Wait(500)
-		for k,v in pairs (Config.PedList) do
+		for k = 1, #Config.PedList, 1 do
+			v = Config.PedList[k]
 			local playerCoords = GetEntityCoords(PlayerPedId())
 			local dist = #(playerCoords - v.coords)
 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -5,6 +5,8 @@ author 'sjpfeiffer'
 description 'A ped spawner for fivem'
 version '1.2.0'
 
+lua54 'yes'
+
 client_scripts {
 	'config.lua',
 	'client/main.lua'


### PR DESCRIPTION
I added functionality to spawn multiple peds that are within distance of the player. I also increased the delay to 500ms, which lightened cpu demand and the difference is seemingly imperceptible, given you can also adjust distance. When you think that most of the time, the player will be out of distance of spawned peds, I don't see the purpose of checking so often. I enabled lua5.4 in fxmanifest, as I'm using this more and more in resources for garbage collection benefits. Great job on the resource.