### PR TITLE
add export createPed for other resources

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1,7 +1,7 @@
 Citizen.CreateThread(function()
 	while true do
 		Citizen.Wait(500)
-		for k,v in pairs(Conifg.PedList) do
+		for k,v in pairs(Config.PedList) do
 			local playerCoords = GetEntityCoords(PlayerPedId())
 			local dist = #(playerCoords - v.coords)
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,8 +1,7 @@
 Citizen.CreateThread(function()
 	while true do
 		Citizen.Wait(500)
-		for k = 1, #Config.PedList, 1 do
-			v = Config.PedList[k]
+		for k,v in pairs(Conifg.PedList) do
 			local playerCoords = GetEntityCoords(PlayerPedId())
 			local dist = #(playerCoords - v.coords)
 
@@ -25,6 +24,10 @@ Citizen.CreateThread(function()
 			end
 		end
 	end
+end)
+
+exports('createPed', function(id, data)
+	Config.PedList[id] = data		
 end)
 
 function nearPed(model, coords, heading, gender, animDict, animName, scenario)


### PR DESCRIPTION
For me it makes it easier to handle peds in one resource, instead of adding more into the Config one by one.
Usage:
```lua
            exports['ped_spawner']:createPed('HarvestSeller',{
                model = v.ped, -- change to your ped string
                coords = v.coords, -- ped coords
                heading = v.heading,  -- ped heading
                gender = v.gender,  -- ped gender 'male' or 'female'
                isRendered = false,
                ped = nil,
            })
```
Pair loop might be slower than the numeric loop but it is to enable non numeric key of the table to be looped as well.