### PR TITLE
Added qtarget functionality

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -7,7 +7,7 @@ Citizen.CreateThread(function()
 			local dist = #(playerCoords - v.coords)
 
 			if dist < Config.Distance and not v.isRendered then
-				local ped = nearPed(v.model, v.coords, v.heading, v.gender, v.animDict, v.animName, v.scenario)
+				local ped = nearPed(v.model, v.coords, v.heading, v.gender, v.animDict, v.animName, v.scenario, v.options, v.distance)
 				v.ped = ped
 				v.isRendered = true
 			end
@@ -20,6 +20,7 @@ Citizen.CreateThread(function()
 					end
 				end
 				DeletePed(v.ped)
+				exports.qtarget:RemoveZone("ped_spawner-"..v.ped)
 				v.ped = nil
 				v.isRendered = false
 			end
@@ -27,7 +28,7 @@ Citizen.CreateThread(function()
 	end
 end)
 
-function nearPed(model, coords, heading, gender, animDict, animName, scenario)
+function nearPed(model, coords, heading, gender, animDict, animName, scenario, options, distance)
 	local genderNum = 0
 --AddEventHandler('nearPed', function(model, coords, heading, gender, animDict, animName)
 	-- Request the models of the peds from the server, so they can be ready to spawn.
@@ -86,6 +87,17 @@ function nearPed(model, coords, heading, gender, animDict, animName, scenario)
 			Citizen.Wait(50)
 			SetEntityAlpha(ped, i, false)
 		end
+	end
+
+	if options and distance then
+		exports.qtarget:AddEntityZone("ped_spawner-"..ped, ped, {
+			name = "ped_spawner-"..ped,
+			heading=GetEntityHeading(ped),
+			debugPoly=false,
+		}, {
+			options = options,
+			distance = distance
+		})
 	end
 
 	return ped

--- a/config.lua
+++ b/config.lua
@@ -26,6 +26,15 @@ Config.PedList = {
 		--animName = "", --The animation name. Optional. Comment out or delete if not using.
 	    isRendered = false,
         ped = nil,
+		options = {
+            {
+                type = "client",
+                event = "qb-clothing:client:openBarberMenu",
+                icon = "fas fa-cut",
+                label = "Change Haircut",
+            },
+        },
+		distance = 3.5,
     },
 	
 	{
@@ -35,6 +44,15 @@ Config.PedList = {
 		gender = "female", 
 	    isRendered = false,
         ped = nil,
+		options = {
+            {
+                type = "client",
+                event = "qb-clothing:client:openBarberMenu",
+                icon = "fas fa-cut",
+                label = "Change Haircut",
+            },
+        },
+		distance = 3.5,
     },
 	
 	{
@@ -44,6 +62,15 @@ Config.PedList = {
 		gender = "female", 
 	    isRendered = false,
         ped = nil,
+		options = {
+            {
+                type = "client",
+                event = "qb-clothing:client:openBarberMenu",
+                icon = "fas fa-cut",
+                label = "Change Haircut",
+            },
+        },
+		distance = 3.5,
     },
 	
 	{
@@ -53,6 +80,15 @@ Config.PedList = {
 		gender = "female", 
 	    isRendered = false,
         ped = nil,
+		options = {
+            {
+                type = "client",
+                event = "qb-clothing:client:openBarberMenu",
+                icon = "fas fa-cut",
+                label = "Change Haircut",
+            },
+        },
+		distance = 3.5,
     },
 	
 	{
@@ -62,6 +98,15 @@ Config.PedList = {
 		gender = "female", 
 	    isRendered = false,
         ped = nil,
+		options = {
+            {
+                type = "client",
+                event = "qb-clothing:client:openBarberMenu",
+                icon = "fas fa-cut",
+                label = "Change Haircut",
+            },
+        },
+		distance = 3.5,
     },
 	
 	{
@@ -71,6 +116,15 @@ Config.PedList = {
 		gender = "female", 
 	    isRendered = false,
         ped = nil,
+		options = {
+            {
+                type = "client",
+                event = "qb-clothing:client:openBarberMenu",
+                icon = "fas fa-cut",
+                label = "Change Haircut",
+            },
+        },
+		distance = 3.5,
     },
 	
 	----------------------------------------

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -7,6 +7,10 @@ version '1.2.0'
 
 lua54 'yes'
 
+dependencies {
+	"qtarget"
+}
+
 client_scripts {
 	'config.lua',
 	'client/main.lua'


### PR DESCRIPTION
Allow for peds to have qtarget options added via `AddEntityZone`, and included examples in the `BARBER SHOPS` section of the config.